### PR TITLE
Move env in execSync calls into context to be multiplatform compatible

### DIFF
--- a/packages/php-symfony/src/executors/build/executor.spec.ts
+++ b/packages/php-symfony/src/executors/build/executor.spec.ts
@@ -62,8 +62,8 @@ describe('Build Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(2);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `COMPOSER_MIRROR_PATH_REPOS=1 composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --quiet`,
-      expectedOptions
+      `composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --quiet`,
+      { ...expectedOptions, env: { ...expectedOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' } }
     );
     expect(cp.execSync).toHaveBeenCalledWith(`composer dump-autoload -a -o`, expectedOptions);
     expect(output.success).toBe(true);
@@ -81,8 +81,8 @@ describe('Build Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(3);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `COMPOSER_MIRROR_PATH_REPOS=1 composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --quiet`,
-      expectedOptions
+      `composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --quiet`,
+      { ...expectedOptions, env: { ...expectedOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' } }
     );
     expect(cp.execSync).toHaveBeenCalledWith(`composer dump-autoload -a -o`, expectedOptions);
     expect(cp.execSync).toHaveBeenCalledWith(
@@ -105,8 +105,8 @@ describe('Build Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(3);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `COMPOSER_MIRROR_PATH_REPOS=1 composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
-      expectedProdOptions
+      `composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
+      { ...expectedProdOptions, env: { ...expectedProdOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' } }
     );
     expect(cp.execSync).toHaveBeenCalledWith(`composer dump-autoload -a -o --no-dev`, expectedProdOptions);
     expect(cp.execSync).toHaveBeenCalledWith(
@@ -127,8 +127,8 @@ describe('Build Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(2);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `COMPOSER_MIRROR_PATH_REPOS=1 composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
-      expectedProdOptions
+      `composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
+      { ...expectedProdOptions, env: { ...expectedProdOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' } }
     );
     expect(cp.execSync).toHaveBeenCalledWith(`composer dump-autoload -a -o --no-dev`, expectedProdOptions);
     expect(output.success).toBe(true);
@@ -157,8 +157,8 @@ describe('Build Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(3);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `COMPOSER_MIRROR_PATH_REPOS=1 composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
-      expectedProdOptions
+      `composer install --prefer-dist --no-progress --no-interaction --optimize-autoloader --no-scripts --no-dev --quiet`,
+      { ...expectedProdOptions, env: { ...expectedProdOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' } }
     );
     expect(cp.execSync).toHaveBeenCalledWith(`composer dump-autoload -a -o --no-dev`, expectedProdOptions);
     expect(cp.execSync).toHaveBeenCalledWith(

--- a/packages/php-symfony/src/executors/build/executor.spec.ts
+++ b/packages/php-symfony/src/executors/build/executor.spec.ts
@@ -15,7 +15,13 @@ jest.mock('child_process', () => ({
 
 import * as cp from 'child_process';
 
-const expectedEnv = { HOME: expect.any(String), PATH: expect.any(String), PHP_INI_DIR: expect.any(String) };
+const expectedEnv = {
+  HOME: expect.any(String),
+  PATH: expect.any(String),
+  PHP_INI_DIR: expect.any(String),
+  COMPOSER_HOME: expect.any(String),
+  APPDATA: expect.any(String),
+};
 const expectedOptions = { cwd: '/root/dist/apps/symfony', env: expectedEnv, stdio: 'inherit' };
 const expectedProdOptions = {
   cwd: '/root/dist/apps/symfony',

--- a/packages/php-symfony/src/executors/build/executor.ts
+++ b/packages/php-symfony/src/executors/build/executor.ts
@@ -64,7 +64,10 @@ function build(context: ExecutorContext, destination: string): void {
   const devParams = context.configurationName === 'production' ? ' --no-dev' : '';
   const assetParams = context.configurationName === 'production' ? '' : ' --relative';
 
-  execSync(`COMPOSER_MIRROR_PATH_REPOS=1 composer install ${installParams.join(' ')}`.trim(), executorOptions);
+  execSync(`composer install ${installParams.join(' ')}`.trim(), {
+    ...executorOptions,
+    env: { ...executorOptions.env, COMPOSER_MIRROR_PATH_REPOS: '1' },
+  });
   execSync(`composer dump-autoload -a -o${devParams}`, executorOptions);
   if (existsSync(`${destination}/bin/console`)) {
     execSync(`php bin/console assets:install${assetParams} public --no-interaction`, executorOptions);

--- a/packages/php-symfony/src/executors/e2e/executor.spec.ts
+++ b/packages/php-symfony/src/executors/e2e/executor.spec.ts
@@ -15,7 +15,13 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 
 describe('E2E Test Executor', () => {
-  const expectedEnv = { HOME: expect.any(String), PATH: expect.any(String), PHP_INI_DIR: expect.any(String) };
+  const expectedEnv = {
+    HOME: expect.any(String),
+    PATH: expect.any(String),
+    PHP_INI_DIR: expect.any(String),
+    COMPOSER_HOME: expect.any(String),
+    APPDATA: expect.any(String),
+  };
   const expectedOptions = { cwd: '/root/apps/symfony', env: expectedEnv, stdio: 'inherit' };
   const spyOnExists = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
 

--- a/packages/php-symfony/src/executors/lint/executor.spec.ts
+++ b/packages/php-symfony/src/executors/lint/executor.spec.ts
@@ -25,7 +25,13 @@ jest.mock('fs', () => ({
 import * as fs from 'fs';
 
 describe('Lint Executor', () => {
-  const expectedEnv = { HOME: expect.any(String), PATH: expect.any(String), PHP_INI_DIR: expect.any(String) };
+  const expectedEnv = {
+    HOME: expect.any(String),
+    PATH: expect.any(String),
+    PHP_INI_DIR: expect.any(String),
+    COMPOSER_HOME: expect.any(String),
+    APPDATA: expect.any(String),
+  };
   const expectedOptions = { cwd: '/root/apps/symfony', env: expectedEnv, stdio: 'inherit' };
   const expectedPaths = ['config', 'src'];
 

--- a/packages/php-symfony/src/executors/test/executor.spec.ts
+++ b/packages/php-symfony/src/executors/test/executor.spec.ts
@@ -14,7 +14,13 @@ jest.mock('child_process', () => ({
 import * as cp from 'child_process';
 
 describe('Test Executor', () => {
-  const expectedEnv = { HOME: expect.any(String), PATH: expect.any(String), PHP_INI_DIR: expect.any(String) };
+  const expectedEnv = {
+    HOME: expect.any(String),
+    PATH: expect.any(String),
+    PHP_INI_DIR: expect.any(String),
+    COMPOSER_HOME: expect.any(String),
+    APPDATA: expect.any(String),
+  };
   const expectedOptions = { cwd: '/root/apps/symfony', env: expectedEnv, stdio: 'inherit' };
 
   let options: TestExecutorSchema;

--- a/packages/php-symfony/src/executors/utils/executor-utils.ts
+++ b/packages/php-symfony/src/executors/utils/executor-utils.ts
@@ -1,4 +1,4 @@
-import { execSync, ExecSyncOptions } from 'child_process';
+import { ExecSyncOptions } from 'child_process';
 import { ExecutorContext } from '@nx/devkit';
 
 export function getProjectPath(context: ExecutorContext): string {
@@ -14,6 +14,8 @@ export function getEnv(): NodeJS.ProcessEnv {
     PHP_INI_DIR: process.env.PHP_INI_DIR || '',
     HOME: process.env.HOME || '',
     PATH: process.env.PATH || '',
+    COMPOSER_HOME: process.env.COMPOSER_HOME || '',
+    APPDATA: process.env.APPDATA || '',
   };
 }
 


### PR DESCRIPTION
This pr moves the env initialization for `composer install` into execSync context as it can handle different runtimes like bash but also powershell