### PR TITLE
Remove safety fallback for php-cs-fixer and PHPStan

### DIFF
--- a/packages/php-symfony/src/executors/lint/executor.spec.ts
+++ b/packages/php-symfony/src/executors/lint/executor.spec.ts
@@ -181,7 +181,7 @@ describe('Lint Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(1);
     expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --format=gitlab > gl-cs-fixer.json 2>/dev/null || true',
+      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --format=gitlab > gl-cs-fixer.json 2>/dev/null',
       expectedOptions,
     );
     expect(output.success).toBe(true);
@@ -209,7 +209,7 @@ describe('Lint Executor', () => {
 
     expect(cp.execSync).toHaveBeenCalledTimes(1);
     expect(cp.execSync).toHaveBeenCalledWith(
-      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --error-format=gitlab > gl-phpstan.json 2>/dev/null || true',
+      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --error-format=gitlab > gl-phpstan.json 2>/dev/null',
       expectedOptions,
     );
     expect(output.success).toBe(true);

--- a/packages/php-symfony/src/executors/lint/executor.ts
+++ b/packages/php-symfony/src/executors/lint/executor.ts
@@ -41,7 +41,7 @@ export default async function runExecutor(options: LintExecutorSchema, context: 
       const fileParts = options.outputFile.split('.');
       const fileEnding = fileParts.pop();
       const pathToOutputFile = fileParts.join('.') + '-cs-fixer.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null || true';
+      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
     }
     execSync(
       `php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no${lintParams}`.trim(),
@@ -62,7 +62,7 @@ export default async function runExecutor(options: LintExecutorSchema, context: 
       const fileParts = options.outputFile.split('.');
       const fileEnding = fileParts.pop();
       const pathToOutputFile = fileParts.join('.') + '-phpstan.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null || true';
+      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
     }
 
     execSync(


### PR DESCRIPTION
This change causes that a CI job will fail on errors also if outputFile is being used.