### PR TITLE
refactor lint executor: delegate to composer scripts

### DIFF
--- a/packages/php-symfony/src/executors/lint/executor.spec.ts
+++ b/packages/php-symfony/src/executors/lint/executor.spec.ts
@@ -46,56 +46,151 @@ describe('Lint Executor', () => {
     jest.clearAllMocks();
   });
 
-  it('runs composer run lint by default', async () => {
-    const output = await executor(options, context);
+  describe('without outputFile', () => {
+    it('runs composer run lint', async () => {
+      const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith('composer run lint', expectedOptions);
-    expect(output.success).toBe(true);
-  });
-
-  it('runs composer run lint-ci and redirects output when outputFile is set', async () => {
-    options.outputFile = 'gl-code-quality.json';
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'composer run lint-ci > gl-code-quality.json 2>/dev/null',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('returns success when lint script is not defined in composer.json', async () => {
-    (cp.execSync as jest.Mock).mockImplementation(() => {
-      const err = new Error("Script 'lint' not defined in this package");
-      throw err;
+      expect(cp.execSync).toHaveBeenCalledTimes(1);
+      expect(cp.execSync).toHaveBeenCalledWith('composer run lint', expectedOptions);
+      expect(output.success).toBe(true);
     });
 
-    const output = await executor(options, context);
+    it('returns success when lint script is not defined in composer.json', async () => {
+      (cp.execSync as jest.Mock).mockImplementation(() => {
+        throw new Error("Script 'lint' not defined in this package");
+      });
 
-    expect(output.success).toBe(true);
-  });
+      const output = await executor(options, context);
 
-  it('returns success when lint-ci script is not defined in composer.json', async () => {
-    options.outputFile = 'gl-code-quality.json';
-    (cp.execSync as jest.Mock).mockImplementation(() => {
-      const err = new Error("Script 'lint-ci' not defined in this package");
-      throw err;
+      expect(output.success).toBe(true);
     });
 
-    const output = await executor(options, context);
+    it('returns failure when lint script exits with a real error', async () => {
+      (cp.execSync as jest.Mock).mockImplementation(() => {
+        throw new Error('Command failed: composer run lint');
+      });
 
-    expect(output.success).toBe(true);
+      const output = await executor(options, context);
+
+      expect(output.success).toBe(false);
+    });
   });
 
-  it('returns failure when lint script exits with a real error', async () => {
-    (cp.execSync as jest.Mock).mockImplementation(() => {
-      throw new Error('Command failed: composer run lint');
+  describe('with outputFile and reportScripts', () => {
+    beforeEach(() => {
+      options.outputFile = 'gl.json';
+      options.reportScripts = [
+        { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+        { script: 'phpstan-ci', suffix: 'phpstan' },
+      ];
     });
 
-    const output = await executor(options, context);
+    it('runs lint-static first, then each report script with a derived output path', async () => {
+      const output = await executor(options, context);
 
-    expect(output.success).toBe(false);
+      expect(cp.execSync).toHaveBeenCalledTimes(3);
+      expect(cp.execSync).toHaveBeenNthCalledWith(1, 'composer run lint-static', expectedOptions);
+      expect(cp.execSync).toHaveBeenNthCalledWith(
+        2,
+        'composer run lint-cs-ci > gl-cs-fixer.json 2>/dev/null',
+        expectedOptions,
+      );
+      expect(cp.execSync).toHaveBeenNthCalledWith(
+        3,
+        'composer run phpstan-ci > gl-phpstan.json 2>/dev/null',
+        expectedOptions,
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('derives report filenames correctly for nested paths', async () => {
+      options.outputFile = 'reports/gl.json';
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenNthCalledWith(
+        2,
+        'composer run lint-cs-ci > reports/gl-cs-fixer.json 2>/dev/null',
+        expectedOptions,
+      );
+      expect(cp.execSync).toHaveBeenNthCalledWith(
+        3,
+        'composer run phpstan-ci > reports/gl-phpstan.json 2>/dev/null',
+        expectedOptions,
+      );
+      expect(output.success).toBe(true);
+    });
+
+    it('aborts after lint-static failure without running report scripts', async () => {
+      (cp.execSync as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Command failed: composer run lint-static');
+      });
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenCalledTimes(1);
+      expect(output.success).toBe(false);
+    });
+
+    it('returns failure when a report script exits with a real error', async () => {
+      (cp.execSync as jest.Mock)
+        .mockImplementationOnce(() => undefined) // lint-static ok
+        .mockImplementationOnce(() => {
+          throw new Error('Command failed: composer run lint-cs-ci');
+        });
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenCalledTimes(2);
+      expect(output.success).toBe(false);
+    });
+
+    it('returns success when lint-static is not defined in composer.json', async () => {
+      (cp.execSync as jest.Mock)
+        .mockImplementationOnce(() => {
+          throw new Error("Script 'lint-static' not defined in this package");
+        })
+        .mockImplementation(() => undefined);
+
+      const output = await executor(options, context);
+
+      // lint-static treated as success -> report scripts still run
+      expect(cp.execSync).toHaveBeenCalledTimes(3);
+      expect(output.success).toBe(true);
+    });
+
+    it('returns success when a report script is not defined in composer.json', async () => {
+      (cp.execSync as jest.Mock)
+        .mockImplementationOnce(() => undefined) // lint-static ok
+        .mockImplementationOnce(() => {
+          throw new Error("Script 'lint-cs-ci' not defined in this package");
+        })
+        .mockImplementationOnce(() => undefined); // phpstan-ci ok
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenCalledTimes(3);
+      expect(output.success).toBe(true);
+    });
+
+    it('runs only lint-static when reportScripts is empty', async () => {
+      options.reportScripts = [];
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenCalledTimes(1);
+      expect(cp.execSync).toHaveBeenCalledWith('composer run lint-static', expectedOptions);
+      expect(output.success).toBe(true);
+    });
+
+    it('runs only lint-static when reportScripts is not set', async () => {
+      delete options.reportScripts;
+
+      const output = await executor(options, context);
+
+      expect(cp.execSync).toHaveBeenCalledTimes(1);
+      expect(cp.execSync).toHaveBeenCalledWith('composer run lint-static', expectedOptions);
+      expect(output.success).toBe(true);
+    });
   });
 });

--- a/packages/php-symfony/src/executors/lint/executor.spec.ts
+++ b/packages/php-symfony/src/executors/lint/executor.spec.ts
@@ -2,27 +2,10 @@ import { ExecutorContext } from '@nx/devkit';
 import { LintExecutorSchema } from './schema';
 import executor from './executor';
 
-// mock exec of child_process
 jest.mock('child_process', () => ({
-  exec: jest.fn((command, options, callback) => {
-    if (callback) callback(null, { stdout: '' });
-  }),
-  execSync: jest.fn((command, options, callback) => {
-    if (callback) callback(null, { stdout: '' });
-  }),
+  execSync: jest.fn(),
 }));
 import * as cp from 'child_process';
-
-jest.mock('fs', () => ({
-  readdirSync: jest.fn(() => [
-    { name: 'project.json', isDirectory: () => false },
-    { name: 'config', isDirectory: () => true },
-    { name: 'src', isDirectory: () => true },
-    { name: 'vendor', isDirectory: () => true },
-  ]),
-  existsSync: jest.fn(() => false),
-}));
-import * as fs from 'fs';
 
 describe('Lint Executor', () => {
   const expectedEnv = {
@@ -43,7 +26,7 @@ describe('Lint Executor', () => {
       root: '/root',
       cwd: '/root',
       projectName: 'my-app',
-      targetName: 'build',
+      targetName: 'lint',
       nxJsonConfiguration: {},
       projectsConfigurations: {
         version: 2,
@@ -63,163 +46,56 @@ describe('Lint Executor', () => {
     jest.clearAllMocks();
   });
 
-  it('can lint [PHP only]', async () => {
-    const output = await executor(options, context);
-
-    expect(cp.execSync).not.toHaveBeenCalled();
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [container only]', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/bin/console');
+  it('runs composer run lint by default', async () => {
     const output = await executor(options, context);
 
     expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
+    expect(cp.execSync).toHaveBeenCalledWith('composer run lint', expectedOptions);
     expect(output.success).toBe(true);
   });
 
-  it('can lint [PHP+container]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/bin/parallel-lint',
-      );
+  it('runs composer run lint-ci and redirects output when outputFile is set', async () => {
+    options.outputFile = 'gl-code-quality.json';
     const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php vendor/bin/parallel-lint --colors config src`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [container+Twig]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/symfony/twig-bundle',
-      );
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
+    expect(cp.execSync).toHaveBeenCalledTimes(1);
     expect(cp.execSync).toHaveBeenCalledWith(
-      `php bin/console lint:twig --show-deprecations config src`,
+      'composer run lint-ci > gl-code-quality.json 2>/dev/null',
       expectedOptions,
     );
     expect(output.success).toBe(true);
   });
 
-  it('can lint [container+YAML]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/symfony/yaml',
-      );
+  it('returns success when lint script is not defined in composer.json', async () => {
+    (cp.execSync as jest.Mock).mockImplementation(() => {
+      const err = new Error("Script 'lint' not defined in this package");
+      throw err;
+    });
+
     const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:yaml --parse-tags config src`, expectedOptions);
     expect(output.success).toBe(true);
   });
 
-  it('can lint [container+doctrine]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) =>
-          path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/doctrine/doctrine-bundle',
-      );
+  it('returns success when lint-ci script is not defined in composer.json', async () => {
+    options.outputFile = 'gl-code-quality.json';
+    (cp.execSync as jest.Mock).mockImplementation(() => {
+      const err = new Error("Script 'lint-ci' not defined in this package");
+      throw err;
+    });
+
     const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console doctrine:schema:validate --skip-sync`, expectedOptions);
     expect(output.success).toBe(true);
   });
 
-  it('can lint [PHP-CS-Fixer] with default options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --dry-run',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [PHP-CS-Fixer] and ignore env', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    options.fix = true;
-    options.ignoreEnv = true;
-    const expectedOptions = {
-      cwd: '/root/apps/symfony',
-      env: { ...expectedEnv, PHP_CS_FIXER_IGNORE_ENV: expect.any(String) },
-      stdio: 'inherit',
-    };
+  it('returns failure when lint script exits with a real error', async () => {
+    (cp.execSync as jest.Mock).mockImplementation(() => {
+      throw new Error('Command failed: composer run lint');
+    });
 
     const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [PHP-CS-Fixer] with all options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    options.format = 'gitlab';
-    options.outputFile = 'gl.json';
-    options.fix = true;
-
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --format=gitlab > gl-cs-fixer.json 2>/dev/null',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [PHPStan] with default options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/phpstan');
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [PHPStan] with all options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/phpstan');
-    options.format = 'gitlab';
-    options.outputFile = 'gl.json';
-    options.fix = true;
-
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --error-format=gitlab > gl-phpstan.json 2>/dev/null',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint all components', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(7);
-    expect(output.success).toBe(true);
+    expect(output.success).toBe(false);
   });
 });

--- a/packages/php-symfony/src/executors/lint/executor.ts
+++ b/packages/php-symfony/src/executors/lint/executor.ts
@@ -1,103 +1,27 @@
 import { LintExecutorSchema } from './schema';
-import { getCwd, getExecutorOptions } from '../utils/executor-utils';
+import { getCwd, getEnv } from '../utils/executor-utils';
 import { execSync } from 'child_process';
-import { existsSync, readdirSync } from 'fs';
 import { ExecutorContext } from '@nx/devkit';
 
 export default async function runExecutor(options: LintExecutorSchema, context: ExecutorContext) {
   const cwd = getCwd(context);
-  const commonParams = context.isVerbose ? '-vvv' : '';
+  const scriptName = options.outputFile ? 'lint-ci' : 'lint';
+  const env = { ...getEnv() };
 
-  const relevantDirectories = readdirSync(cwd, { withFileTypes: true })
-    .filter((dir) => dir.isDirectory())
-    .map((dir) => dir.name)
-    .filter((name) => name !== 'var' && name !== 'vendor');
+  const cmd = options.outputFile
+    ? `composer run ${scriptName} > ${options.outputFile} 2>/dev/null`
+    : `composer run ${scriptName}`;
 
-  if (existsSync(`${cwd}/vendor/bin/parallel-lint`)) {
-    console.info('Linting PHP...');
-    execSync(
-      `php vendor/bin/parallel-lint --colors ${relevantDirectories.join(' ')}`.trim(),
-      getExecutorOptions(context),
-    );
+  try {
+    execSync(cmd, { cwd, env, stdio: 'inherit' });
+  } catch (e) {
+    const msg: string = (e as Error).message ?? '';
+    // Composer exits non-zero with "Script ... not defined" when the script is missing
+    if (msg.includes('Script') && msg.includes('not defined')) {
+      return { success: true };
+    }
+    return { success: false };
   }
-
-  if (existsSync(`${cwd}/vendor/bin/php-cs-fixer`)) {
-    console.info('Linting using PHP-CS-Fixer...');
-
-    const executorOptions = getExecutorOptions(context);
-    if (options.ignoreEnv) {
-      executorOptions.env.PHP_CS_FIXER_IGNORE_ENV = '1';
-    }
-    let lintParams = options.fix ? '' : ' --dry-run';
-    if (options.format) {
-      lintParams += ` --format=${options.format}`;
-    }
-    if (commonParams){
-      lintParams += ' ' + commonParams;
-    }
-
-    if (options.outputFile) {
-      // in case of a given outputFile the results will be written to the file and errors will be ignored
-      const fileParts = options.outputFile.split('.');
-      const fileEnding = fileParts.pop();
-      const pathToOutputFile = fileParts.join('.') + '-cs-fixer.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
-    }
-    execSync(
-      `php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no${lintParams}`.trim(),
-      executorOptions,
-    );
-  }
-
-  if (existsSync(`${cwd}/vendor/bin/phpstan`)) {
-    console.info('Linting using PHPStan...');
-
-    let lintParams = options.format ? ` --error-format=${options.format}` : '';
-    if (commonParams){
-      lintParams += ' ' + commonParams;
-    }
-
-    if (options.outputFile) {
-      // in case of a given outputFile the results will be written to the file and errors will be ignored
-      const fileParts = options.outputFile.split('.');
-      const fileEnding = fileParts.pop();
-      const pathToOutputFile = fileParts.join('.') + '-phpstan.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
-    }
-
-    execSync(
-      `php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress${lintParams}`.trim(),
-      getExecutorOptions(context),
-    );
-  }
-
-  if (existsSync(`${cwd}/bin/console`)) {
-    console.info('Linting container...');
-    execSync(`php bin/console lint:container ${commonParams}`.trim(), getExecutorOptions(context));
-
-    if (existsSync(`${cwd}/vendor/symfony/yaml`)) {
-      console.info('Linting YAML...');
-      execSync(
-        `php bin/console lint:yaml --parse-tags ${relevantDirectories.join(' ')} ${commonParams}`.trim(),
-        getExecutorOptions(context),
-      );
-    }
-
-    if (existsSync(`${cwd}/vendor/symfony/twig-bundle`)) {
-      console.info('Linting Twig...');
-      execSync(
-        `php bin/console lint:twig --show-deprecations ${relevantDirectories.join(' ')} ${commonParams}`.trim(),
-        getExecutorOptions(context),
-      );
-    }
-
-    if (existsSync(`${cwd}/vendor/doctrine/doctrine-bundle`)) {
-      console.info('Linting Doctrine schema...');
-      execSync(`php bin/console doctrine:schema:validate --skip-sync`, getExecutorOptions(context));
-    }
-  }
-
-  console.info('Done Linting.');
 
   return { success: true };
 }

--- a/packages/php-symfony/src/executors/lint/executor.ts
+++ b/packages/php-symfony/src/executors/lint/executor.ts
@@ -3,24 +3,53 @@ import { getCwd, getEnv } from '../utils/executor-utils';
 import { execSync } from 'child_process';
 import { ExecutorContext } from '@nx/devkit';
 
-export default async function runExecutor(options: LintExecutorSchema, context: ExecutorContext) {
-  const cwd = getCwd(context);
-  const scriptName = options.outputFile ? 'lint-ci' : 'lint';
-  const env = { ...getEnv() };
+function buildReportFilePath(outputFile: string, suffix: string): string {
+  const parts = outputFile.split('.');
+  const ext = parts.pop();
+  return `${parts.join('.')}-${suffix}.${ext}`;
+}
 
-  const cmd = options.outputFile
-    ? `composer run ${scriptName} > ${options.outputFile} 2>/dev/null`
-    : `composer run ${scriptName}`;
+function runComposerScript(script: string, cwd: string, env: NodeJS.ProcessEnv, redirect?: string): boolean {
+  const cmd = redirect
+    ? `composer run ${script} > ${redirect} 2>/dev/null`
+    : `composer run ${script}`;
 
   try {
     execSync(cmd, { cwd, env, stdio: 'inherit' });
+    return true;
   } catch (e) {
     const msg: string = (e as Error).message ?? '';
     // Composer exits non-zero with "Script ... not defined" when the script is missing
     if (msg.includes('Script') && msg.includes('not defined')) {
-      return { success: true };
+      return true;
     }
+    return false;
+  }
+}
+
+export default async function runExecutor(options: LintExecutorSchema, context: ExecutorContext) {
+  const cwd = getCwd(context);
+  const env = { ...getEnv() };
+
+  if (!options.outputFile) {
+    const success = runComposerScript('lint', cwd, env);
+    return { success };
+  }
+
+  // Run the static checks first (no report output); abort on failure.
+  const staticSuccess = runComposerScript('lint-static', cwd, env);
+  if (!staticSuccess) {
     return { success: false };
+  }
+
+  // Run each report-producing script and redirect its output to a derived filename.
+  const reportScripts = options.reportScripts ?? [];
+  for (const { script, suffix } of reportScripts) {
+    const reportFile = buildReportFilePath(options.outputFile, suffix);
+    const success = runComposerScript(script, cwd, env, reportFile);
+    if (!success) {
+      return { success: false };
+    }
   }
 
   return { success: true };

--- a/packages/php-symfony/src/executors/lint/schema.d.ts
+++ b/packages/php-symfony/src/executors/lint/schema.d.ts
@@ -1,3 +1,9 @@
+export interface ReportScript {
+  script: string;
+  suffix: string;
+}
+
 export interface LintExecutorSchema {
   outputFile?: string;
+  reportScripts?: ReportScript[];
 }

--- a/packages/php-symfony/src/executors/lint/schema.d.ts
+++ b/packages/php-symfony/src/executors/lint/schema.d.ts
@@ -1,6 +1,3 @@
 export interface LintExecutorSchema {
-  format?: string;
   outputFile?: string;
-  fix?: boolean;
-  ignoreEnv?: boolean;
 }

--- a/packages/php-symfony/src/executors/lint/schema.json
+++ b/packages/php-symfony/src/executors/lint/schema.json
@@ -5,6 +5,30 @@
   "title": "Lint executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "outputFile": {
+      "type": "string",
+      "description": "Base path for report output files (e.g. 'gl.json'). When set, reportScripts are run individually and their output is written to derived filenames."
+    },
+    "reportScripts": {
+      "type": "array",
+      "description": "Composer scripts that produce file reports when outputFile is set. Each entry maps a script name to a filename suffix.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "Composer script name (e.g. 'lint-cs-ci')"
+          },
+          "suffix": {
+            "type": "string",
+            "description": "Suffix inserted before the file extension (e.g. 'cs-fixer' -> 'gl-cs-fixer.json')"
+          }
+        },
+        "required": ["script", "suffix"],
+        "additionalProperties": false
+      }
+    }
+  },
   "required": []
 }

--- a/packages/php-symfony/src/generators/application/generator.spec.ts
+++ b/packages/php-symfony/src/generators/application/generator.spec.ts
@@ -46,5 +46,14 @@ describe('php-symfony generator', () => {
 
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
+    expect(config.targets.lint).toEqual({
+      executor: '@nxt-php/php-symfony:lint',
+      options: {
+        reportScripts: [
+          { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+          { script: 'phpstan-ci', suffix: 'phpstan' },
+        ],
+      },
+    });
   });
 });

--- a/packages/php-symfony/src/generators/application/generator.ts
+++ b/packages/php-symfony/src/generators/application/generator.ts
@@ -67,6 +67,12 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
       },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
+        options: {
+          reportScripts: [
+            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+            { script: 'phpstan-ci', suffix: 'phpstan' },
+          ],
+        },
       },
       test: {
         executor: '@nxt-php/php-symfony:test',

--- a/packages/php-symfony/src/generators/library/generator.spec.ts
+++ b/packages/php-symfony/src/generators/library/generator.spec.ts
@@ -45,5 +45,14 @@ describe('php-symfony generator', () => {
 
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
+    expect(config.targets.lint).toEqual({
+      executor: '@nxt-php/php-symfony:lint',
+      options: {
+        reportScripts: [
+          { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+          { script: 'phpstan-ci', suffix: 'phpstan' },
+        ],
+      },
+    });
   });
 });

--- a/packages/php-symfony/src/generators/library/generator.ts
+++ b/packages/php-symfony/src/generators/library/generator.ts
@@ -67,6 +67,12 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
       },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
+        options: {
+          reportScripts: [
+            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+            { script: 'phpstan-ci', suffix: 'phpstan' },
+          ],
+        },
       },
       test: {
         executor: '@nxt-php/php-symfony:test',


### PR DESCRIPTION
Replace direct tool detection and invocation (parallel-lint, php-cs-fixer, phpstan, bin/console lint:*) with a composer script dispatcher. Tool configuration and selection moves entirely into `composer.json`, removing the need to update the executor when tools change.

## Execution model

**Without `outputFile`** (local use):
```
composer run lint
```

**With `outputFile`** (CI):
```
composer run lint-static          # static checks; aborts on failure
composer run lint-cs-ci  > gl-cs-fixer.json 2>/dev/null
composer run phpstan-ci  > gl-phpstan.json  2>/dev/null
```

Report scripts and their output filename suffixes are configured explicitly per project via `reportScripts`:

```json
"options": {
  "outputFile": "gl.json",
  "reportScripts": [
    { "script": "lint-cs-ci",  "suffix": "cs-fixer" },
    { "script": "phpstan-ci",  "suffix": "phpstan" }
  ]
}
```

The filename is derived from `outputFile` by inserting the suffix before the extension: `gl.json` + `cs-fixer` → `gl-cs-fixer.json`.

## Changes

- Add `reportScripts` option (`{ script, suffix }[]`) to schema
- Run `lint-static` first; abort before report scripts on failure
- Each report script is run individually with output redirected to its derived filename
- Missing composer scripts (`Script not defined`) are treated as success
- Remove `fix`, `ignoreEnv`, `format` options from schema