### PR TITLE
feat: add CI pipeline and release workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.5-cli
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libzip-dev \
+        unzip \
+    && docker-php-ext-install zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,7 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": [
-        "bmewburn.vscode-intelephense-client"
-      ]
+      "extensions": ["bmewburn.vscode-intelephense-client"]
     }
   },
   "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,9 @@
     "ghcr.io/devcontainers/features/node": {
       "version": "24"
     },
-    "ghcr.io/devcontainers/features/php": {},
-    "ghcr.io/devcontainers/features/composer": {}
+    "ghcr.io/devcontainers/features/php": {
+      "installComposer": true
+    }
   },
   "forwardPorts": [],
   "portsAttributes": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,19 @@
 {
   "name": "nxt-php",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "build": {
+    "context": ".",
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/node": {
       "version": "24"
-    },
-    "ghcr.io/devcontainers/features/php": {
-      "installComposer": true
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client"
+      ]
     }
   },
   "forwardPorts": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   main:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      NODE_OPTIONS: --experimental-vm-modules
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: nrwl/nx-set-shas@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx nx format:check
+
+      - run: npx nx affected -t lint test build e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           tools: composer
 
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           node-version: 24
           cache: npm
 
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+
       - run: npm ci
 
       - run: npx nx format:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only allow releases from master
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write      # git tags + changelog commit
+      id-token: write      # npm provenance
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup git user
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - run: npm ci
+
+      - name: Release
+        run: npx nx release --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@
 
 /.nx/cache
 /.nx/workspace-data
+
+/.github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Fix all lint and test failures before pushing. Do not open a PR with a failing C
 
 Releases are triggered manually via the **Release** GitHub Actions workflow (`workflow_dispatch` on `master`).  
 The workflow runs `nx release`, which:
+
 1. Bumps versions based on Conventional Commits
 2. Generates / updates `CHANGELOG.md`
 3. Creates a Git tag and GitHub Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Agent Guidelines
+
+## Git Workflow
+
+- Never push directly to `master`. Always create a branch and open a PR.
+- Branch naming: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`.
+- Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/):
+  - `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
+  - Only `feat:` and `fix:` appear in the changelog / release notes.
+
+## Running Tasks
+
+Always run tasks through Nx, never the underlying tooling directly:
+
+```bash
+# Affected only (recommended during development)
+npx nx affected -t lint test build
+
+# Specific project
+npx nx run php-symfony:test
+npx nx run php-symfony:build
+npx nx run php-symfony:lint
+
+# All e2e tests
+npx nx run php-symfony-e2e:e2e
+```
+
+## Before Opening a PR
+
+```bash
+npx nx format:check
+npx nx affected -t lint test build
+```
+
+Fix all lint and test failures before pushing. Do not open a PR with a failing CI.
+
+## Adding a New Executor or Generator
+
+- Executors live in `packages/php-symfony/src/executors/<name>/`
+- Generators live in `packages/php-symfony/src/generators/<name>/`
+- Each must have: `executor.ts` / `generator.ts`, `schema.json`, `schema.d.ts`, and a `.spec.ts` test file.
+- Register new executors in `packages/php-symfony/executors.json` and generators in `packages/php-symfony/generators.json`.
+
+## Release Process
+
+Releases are triggered manually via the **Release** GitHub Actions workflow (`workflow_dispatch` on `master`).  
+The workflow runs `nx release`, which:
+1. Bumps versions based on Conventional Commits
+2. Generates / updates `CHANGELOG.md`
+3. Creates a Git tag and GitHub Release
+4. Publishes `@nxt-php/php-symfony` to npm
+
+**Required GitHub secret:** `NPM_TOKEN` (npm granular access token with read+write for `@nxt-php/php-symfony`).
+
+## Project Structure
+
+```
+packages/
+  php-symfony/        # @nxt-php/php-symfony – the Nx plugin
+    src/
+      executors/      # Nx executors (build, test, lint, e2e)
+      generators/     # Nx generators (application, library)
+e2e/
+  php-symfony-e2e/    # End-to-end tests for the plugin
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,14 @@ npx nx run php-symfony:lint
 npx nx run php-symfony-e2e:e2e
 ```
 
+## Before Every Commit
+
+```bash
+npx nx format:check
+```
+
+Fix formatting issues with `npx prettier --write <file>` before committing.
+
 ## Before Opening a PR
 
 ```bash

--- a/nx.json
+++ b/nx.json
@@ -45,10 +45,32 @@
     "@nx/eslint:lint": {
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/eslint.config.cjs"],
       "cache": true
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
     }
   },
   "useInferencePlugins": false,
   "defaultBase": "origin/master",
   "neverConnectToCloud": true,
-  "analytics": false
+  "analytics": false,
+  "release": {
+    "projects": ["packages/*"],
+    "projectsRelationship": "fixed",
+    "version": {
+      "conventionalCommits": true,
+      "preVersionCommand": "npx nx run-many -t build",
+      "manifestRootsToUpdate": ["dist/{projectRoot}"]
+    },
+    "changelog": {
+      "workspaceChangelog": {
+        "createRelease": "github"
+      }
+    },
+    "git": {
+      "commitMessage": "chore(release): publish {version} [skip ci]"
+    }
+  }
 }


### PR DESCRIPTION
## CI Pipeline

Adds GitHub Actions workflows and release configuration modelled after established Nx plugin repos (nx-dotnet, nrwl/nx).

### Changes

**`.github/workflows/ci.yml`**
- Triggers on push to `master` and all PRs
- Uses `nrwl/nx-set-shas` to determine affected projects
- Runs `nx affected -t lint test build e2e` + `nx format:check`
- Concurrency group cancels redundant runs on the same PR

**`.github/workflows/release.yml`**
- Triggered manually via `workflow_dispatch` on `master`
- Runs `nx release --yes`: bumps versions, generates changelog, creates GitHub Release, publishes to npm
- Requires `NPM_TOKEN` secret in the repository settings

**`nx.json`**
- Added `release` config: `conventionalCommits`, `preVersionCommand` (build before release), GitHub Release creation
- Added `nx-release-publish` target default pointing to `dist/{projectRoot}`

**`AGENTS.md`**
- Project-specific conventions: git workflow, Conventional Commits, nx task commands, executor/generator structure, release process

### Required setup before first release

Add a GitHub repository secret:
- `NPM_TOKEN` – npm granular access token with read+write for `@nxt-php/php-symfony`