### PR TITLE
fix: remove non-existent composer devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,9 @@
     "ghcr.io/devcontainers/features/node": {
       "version": "24"
     },
-    "ghcr.io/devcontainers/features/php": {},
-    "ghcr.io/devcontainers/features/composer": {}
+    "ghcr.io/devcontainers/features/php": {
+      "installComposer": true
+    }
   },
   "forwardPorts": [],
   "portsAttributes": {}


### PR DESCRIPTION
## Problem

`ghcr.io/devcontainers/features/composer` does not exist in the devcontainer feature registry, causing the container build to fail with:

```
Could not resolve Feature 'ghcr.io/devcontainers/features/composer'.
```

## Fix

Remove the non-existent feature. The `php` feature already installs Composer by default (`installComposer: true`), so no separate feature is needed. Made the default explicit for clarity.