### PR TITLE
feat: delegate lint executor to composer scripts

### DIFF
--- a/packages/php-symfony/src/executors/lint/executor.spec.ts
+++ b/packages/php-symfony/src/executors/lint/executor.spec.ts
@@ -1,28 +1,7 @@
 import { ExecutorContext } from '@nx/devkit';
 import { LintExecutorSchema } from './schema';
+import * as childProcess from 'child_process';
 import executor from './executor';
-
-// mock exec of child_process
-jest.mock('child_process', () => ({
-  exec: jest.fn((command, options, callback) => {
-    if (callback) callback(null, { stdout: '' });
-  }),
-  execSync: jest.fn((command, options, callback) => {
-    if (callback) callback(null, { stdout: '' });
-  }),
-}));
-import * as cp from 'child_process';
-
-jest.mock('fs', () => ({
-  readdirSync: jest.fn(() => [
-    { name: 'project.json', isDirectory: () => false },
-    { name: 'config', isDirectory: () => true },
-    { name: 'src', isDirectory: () => true },
-    { name: 'vendor', isDirectory: () => true },
-  ]),
-  existsSync: jest.fn(() => false),
-}));
-import * as fs from 'fs';
 
 describe('Lint Executor', () => {
   const expectedEnv = {
@@ -32,10 +11,16 @@ describe('Lint Executor', () => {
     COMPOSER_HOME: expect.any(String),
     APPDATA: expect.any(String),
   };
-  const expectedOptions = { cwd: '/root/apps/symfony', env: expectedEnv, stdio: 'inherit' };
+
+  const expectedOptions = {
+    cwd: '/root/apps/symfony',
+    env: expectedEnv,
+    stdio: 'inherit',
+  };
 
   let options: LintExecutorSchema;
   let context: ExecutorContext;
+  let execSyncSpy: jest.SpyInstance;
 
   beforeEach(() => {
     options = {};
@@ -43,183 +28,168 @@ describe('Lint Executor', () => {
       root: '/root',
       cwd: '/root',
       projectName: 'my-app',
-      targetName: 'build',
+      targetName: 'lint',
       nxJsonConfiguration: {},
       projectsConfigurations: {
         version: 2,
         projects: {
           'my-app': {
             root: 'apps/symfony',
-            sourceRoot: 'apps/symfony',
           },
         },
       },
       projectGraph: { nodes: {}, dependencies: {} },
       isVerbose: false,
     };
+    execSyncSpy = jest.spyOn(childProcess, 'execSync').mockReturnValue(Buffer.from(''));
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    execSyncSpy.mockRestore();
   });
 
-  it('can lint [PHP only]', async () => {
-    const output = await executor(options, context);
+  describe('without outputFile', () => {
+    it('runs composer run lint', async () => {
+      const output = await executor(options, context);
 
-    expect(cp.execSync).not.toHaveBeenCalled();
-    expect(output.success).toBe(true);
+      expect(execSyncSpy).toHaveBeenCalledTimes(1);
+      expect(execSyncSpy).toHaveBeenCalledWith('composer run lint', expectedOptions);
+      expect(output.success).toBe(true);
+    });
+
+    it('returns success when lint script is not defined in composer.json', async () => {
+      execSyncSpy.mockImplementation(() => {
+        throw new Error("Script 'lint' not defined in this package");
+      });
+
+      const output = await executor(options, context);
+
+      expect(output.success).toBe(true);
+    });
+
+    it('returns failure when lint script exits with a real error', async () => {
+      execSyncSpy.mockImplementation(() => {
+        throw new Error('Command failed: composer run lint');
+      });
+
+      const output = await executor(options, context);
+
+      expect(output.success).toBe(false);
+    });
   });
 
-  it('can lint [container only]', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/bin/console');
-    const output = await executor(options, context);
+  describe('with outputFile and reportScripts', () => {
+    beforeEach(() => {
+      options.outputFile = 'gl.json';
+      options.reportScripts = [
+        { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+        { script: 'phpstan-ci', suffix: 'phpstan' },
+      ];
+    });
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(output.success).toBe(true);
-  });
+    it('runs lint-static first, then each report script with a derived output path', async () => {
+      const output = await executor(options, context);
 
-  it('can lint [PHP+container]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/bin/parallel-lint',
+      expect(execSyncSpy).toHaveBeenCalledTimes(3);
+      expect(execSyncSpy).toHaveBeenNthCalledWith(1, 'composer run lint-static', expectedOptions);
+      expect(execSyncSpy).toHaveBeenNthCalledWith(
+        2,
+        'composer run lint-cs-ci > gl-cs-fixer.json 2>/dev/null',
+        expectedOptions,
       );
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php vendor/bin/parallel-lint --colors config src`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [container+Twig]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/symfony/twig-bundle',
+      expect(execSyncSpy).toHaveBeenNthCalledWith(
+        3,
+        'composer run phpstan-ci > gl-phpstan.json 2>/dev/null',
+        expectedOptions,
       );
-    const output = await executor(options, context);
+      expect(output.success).toBe(true);
+    });
 
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      `php bin/console lint:twig --show-deprecations config src`,
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+    it('derives report filenames correctly for nested paths', async () => {
+      options.outputFile = 'reports/gl.json';
 
-  it('can lint [container+YAML]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) => path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/symfony/yaml',
+      const output = await executor(options, context);
+
+      expect(execSyncSpy).toHaveBeenNthCalledWith(
+        2,
+        'composer run lint-cs-ci > reports/gl-cs-fixer.json 2>/dev/null',
+        expectedOptions,
       );
-    const output = await executor(options, context);
-
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:yaml --parse-tags config src`, expectedOptions);
-    expect(output.success).toBe(true);
-  });
-
-  it('can lint [container+doctrine]', async () => {
-    jest
-      .spyOn(fs, 'existsSync')
-      .mockImplementation(
-        (path) =>
-          path === '/root/apps/symfony/bin/console' || path === '/root/apps/symfony/vendor/doctrine/doctrine-bundle',
+      expect(execSyncSpy).toHaveBeenNthCalledWith(
+        3,
+        'composer run phpstan-ci > reports/gl-phpstan.json 2>/dev/null',
+        expectedOptions,
       );
-    const output = await executor(options, context);
+      expect(output.success).toBe(true);
+    });
 
-    expect(cp.execSync).toHaveBeenCalledTimes(2);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console lint:container`, expectedOptions);
-    expect(cp.execSync).toHaveBeenCalledWith(`php bin/console doctrine:schema:validate --skip-sync`, expectedOptions);
-    expect(output.success).toBe(true);
-  });
+    it('aborts after lint-static failure without running report scripts', async () => {
+      execSyncSpy.mockImplementationOnce(() => {
+        throw new Error('Command failed: composer run lint-static');
+      });
 
-  it('can lint [PHP-CS-Fixer] with default options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    const output = await executor(options, context);
+      const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --dry-run',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+      expect(execSyncSpy).toHaveBeenCalledTimes(1);
+      expect(output.success).toBe(false);
+    });
 
-  it('can lint [PHP-CS-Fixer] and ignore env', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    options.fix = true;
-    options.ignoreEnv = true;
-    const expectedOptions = {
-      cwd: '/root/apps/symfony',
-      env: { ...expectedEnv, PHP_CS_FIXER_IGNORE_ENV: expect.any(String) },
-      stdio: 'inherit',
-    };
+    it('returns failure when a report script exits with a real error', async () => {
+      execSyncSpy.mockReturnValueOnce(Buffer.from('')).mockImplementationOnce(() => {
+        throw new Error('Command failed: composer run lint-cs-ci');
+      });
 
-    const output = await executor(options, context);
+      const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+      expect(execSyncSpy).toHaveBeenCalledTimes(2);
+      expect(output.success).toBe(false);
+    });
 
-  it('can lint [PHP-CS-Fixer] with all options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/php-cs-fixer');
-    options.format = 'gitlab';
-    options.outputFile = 'gl.json';
-    options.fix = true;
+    it('returns success when lint-static is not defined in composer.json', async () => {
+      execSyncSpy
+        .mockImplementationOnce(() => {
+          throw new Error("Script 'lint-static' not defined in this package");
+        })
+        .mockReturnValue(Buffer.from(''));
 
-    const output = await executor(options, context);
+      const output = await executor(options, context);
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no --format=gitlab > gl-cs-fixer.json 2>/dev/null',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+      expect(execSyncSpy).toHaveBeenCalledTimes(3);
+      expect(output.success).toBe(true);
+    });
 
-  it('can lint [PHPStan] with default options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/phpstan');
-    const output = await executor(options, context);
+    it('returns success when a report script is not defined in composer.json', async () => {
+      execSyncSpy
+        .mockReturnValueOnce(Buffer.from(''))
+        .mockImplementationOnce(() => {
+          throw new Error("Script 'lint-cs-ci' not defined in this package");
+        })
+        .mockReturnValueOnce(Buffer.from(''));
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+      const output = await executor(options, context);
 
-  it('can lint [PHPStan] with all options', async () => {
-    jest.spyOn(fs, 'existsSync').mockImplementation((path) => path === '/root/apps/symfony/vendor/bin/phpstan');
-    options.format = 'gitlab';
-    options.outputFile = 'gl.json';
-    options.fix = true;
+      expect(execSyncSpy).toHaveBeenCalledTimes(3);
+      expect(output.success).toBe(true);
+    });
 
-    const output = await executor(options, context);
+    it('runs only lint-static when reportScripts is empty', async () => {
+      options.reportScripts = [];
 
-    expect(cp.execSync).toHaveBeenCalledTimes(1);
-    expect(cp.execSync).toHaveBeenCalledWith(
-      'php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --error-format=gitlab > gl-phpstan.json 2>/dev/null',
-      expectedOptions,
-    );
-    expect(output.success).toBe(true);
-  });
+      const output = await executor(options, context);
 
-  it('can lint all components', async () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    const output = await executor(options, context);
+      expect(execSyncSpy).toHaveBeenCalledTimes(1);
+      expect(execSyncSpy).toHaveBeenCalledWith('composer run lint-static', expectedOptions);
+      expect(output.success).toBe(true);
+    });
 
-    expect(cp.execSync).toHaveBeenCalledTimes(7);
-    expect(output.success).toBe(true);
+    it('runs only lint-static when reportScripts is not set', async () => {
+      delete options.reportScripts;
+
+      const output = await executor(options, context);
+
+      expect(execSyncSpy).toHaveBeenCalledTimes(1);
+      expect(execSyncSpy).toHaveBeenCalledWith('composer run lint-static', expectedOptions);
+      expect(output.success).toBe(true);
+    });
   });
 });

--- a/packages/php-symfony/src/executors/lint/executor.ts
+++ b/packages/php-symfony/src/executors/lint/executor.ts
@@ -1,103 +1,50 @@
 import { LintExecutorSchema } from './schema';
-import { getCwd, getExecutorOptions } from '../utils/executor-utils';
-import { execSync } from 'child_process';
-import { existsSync, readdirSync } from 'fs';
+import { getCwd, getEnv } from '../utils/executor-utils';
+import * as childProcess from 'child_process';
 import { ExecutorContext } from '@nx/devkit';
+
+function buildReportFilePath(outputFile: string, suffix: string): string {
+  const parts = outputFile.split('.');
+  const ext = parts.pop();
+  return `${parts.join('.')}-${suffix}.${ext}`;
+}
+
+function runComposerScript(script: string, cwd: string, env: NodeJS.ProcessEnv, redirect?: string): boolean {
+  const cmd = redirect ? `composer run ${script} > ${redirect} 2>/dev/null` : `composer run ${script}`;
+
+  try {
+    childProcess.execSync(cmd, { cwd, env, stdio: 'inherit' });
+    return true;
+  } catch (e) {
+    const msg: string = (e as Error).message ?? '';
+    if (msg.includes('Script') && msg.includes('not defined')) {
+      return true;
+    }
+    return false;
+  }
+}
 
 export default async function runExecutor(options: LintExecutorSchema, context: ExecutorContext) {
   const cwd = getCwd(context);
-  const commonParams = context.isVerbose ? '-vvv' : '';
+  const env = { ...getEnv() };
 
-  const relevantDirectories = readdirSync(cwd, { withFileTypes: true })
-    .filter((dir) => dir.isDirectory())
-    .map((dir) => dir.name)
-    .filter((name) => name !== 'var' && name !== 'vendor');
-
-  if (existsSync(`${cwd}/vendor/bin/parallel-lint`)) {
-    console.info('Linting PHP...');
-    execSync(
-      `php vendor/bin/parallel-lint --colors ${relevantDirectories.join(' ')}`.trim(),
-      getExecutorOptions(context),
-    );
+  if (!options.outputFile) {
+    const success = runComposerScript('lint', cwd, env);
+    return { success };
   }
 
-  if (existsSync(`${cwd}/vendor/bin/php-cs-fixer`)) {
-    console.info('Linting using PHP-CS-Fixer...');
-
-    const executorOptions = getExecutorOptions(context);
-    if (options.ignoreEnv) {
-      executorOptions.env.PHP_CS_FIXER_IGNORE_ENV = '1';
-    }
-    let lintParams = options.fix ? '' : ' --dry-run';
-    if (options.format) {
-      lintParams += ` --format=${options.format}`;
-    }
-    if (commonParams){
-      lintParams += ' ' + commonParams;
-    }
-
-    if (options.outputFile) {
-      // in case of a given outputFile the results will be written to the file and errors will be ignored
-      const fileParts = options.outputFile.split('.');
-      const fileEnding = fileParts.pop();
-      const pathToOutputFile = fileParts.join('.') + '-cs-fixer.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
-    }
-    execSync(
-      `php vendor/bin/php-cs-fixer fix --config=php_cs_fixer.dist.php --diff --using-cache=no${lintParams}`.trim(),
-      executorOptions,
-    );
+  const staticOk = runComposerScript('lint-static', cwd, env);
+  if (!staticOk) {
+    return { success: false };
   }
 
-  if (existsSync(`${cwd}/vendor/bin/phpstan`)) {
-    console.info('Linting using PHPStan...');
-
-    let lintParams = options.format ? ` --error-format=${options.format}` : '';
-    if (commonParams){
-      lintParams += ' ' + commonParams;
-    }
-
-    if (options.outputFile) {
-      // in case of a given outputFile the results will be written to the file and errors will be ignored
-      const fileParts = options.outputFile.split('.');
-      const fileEnding = fileParts.pop();
-      const pathToOutputFile = fileParts.join('.') + '-phpstan.' + fileEnding;
-      lintParams += ' > ' + pathToOutputFile + ' 2>/dev/null';
-    }
-
-    execSync(
-      `php -d memory_limit=-1 vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress${lintParams}`.trim(),
-      getExecutorOptions(context),
-    );
-  }
-
-  if (existsSync(`${cwd}/bin/console`)) {
-    console.info('Linting container...');
-    execSync(`php bin/console lint:container ${commonParams}`.trim(), getExecutorOptions(context));
-
-    if (existsSync(`${cwd}/vendor/symfony/yaml`)) {
-      console.info('Linting YAML...');
-      execSync(
-        `php bin/console lint:yaml --parse-tags ${relevantDirectories.join(' ')} ${commonParams}`.trim(),
-        getExecutorOptions(context),
-      );
-    }
-
-    if (existsSync(`${cwd}/vendor/symfony/twig-bundle`)) {
-      console.info('Linting Twig...');
-      execSync(
-        `php bin/console lint:twig --show-deprecations ${relevantDirectories.join(' ')} ${commonParams}`.trim(),
-        getExecutorOptions(context),
-      );
-    }
-
-    if (existsSync(`${cwd}/vendor/doctrine/doctrine-bundle`)) {
-      console.info('Linting Doctrine schema...');
-      execSync(`php bin/console doctrine:schema:validate --skip-sync`, getExecutorOptions(context));
+  for (const { script, suffix } of options.reportScripts ?? []) {
+    const redirect = buildReportFilePath(options.outputFile, suffix);
+    const ok = runComposerScript(script, cwd, env, redirect);
+    if (!ok) {
+      return { success: false };
     }
   }
-
-  console.info('Done Linting.');
 
   return { success: true };
 }

--- a/packages/php-symfony/src/executors/lint/schema.d.ts
+++ b/packages/php-symfony/src/executors/lint/schema.d.ts
@@ -1,6 +1,9 @@
+export interface ReportScript {
+  script: string;
+  suffix: string;
+}
+
 export interface LintExecutorSchema {
-  format?: string;
   outputFile?: string;
-  fix?: boolean;
-  ignoreEnv?: boolean;
+  reportScripts?: ReportScript[];
 }

--- a/packages/php-symfony/src/executors/lint/schema.json
+++ b/packages/php-symfony/src/executors/lint/schema.json
@@ -5,6 +5,29 @@
   "title": "Lint executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "outputFile": {
+      "type": "string",
+      "description": "Base path for report output files (e.g. gl.json). When set, lint-static runs first, then each reportScripts entry writes to a derived path."
+    },
+    "reportScripts": {
+      "type": "array",
+      "description": "Composer scripts to run when outputFile is set, each writing to a derived output path.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "Composer script name"
+          },
+          "suffix": {
+            "type": "string",
+            "description": "Suffix inserted before the file extension in the output filename"
+          }
+        },
+        "required": ["script", "suffix"]
+      }
+    }
+  },
   "required": []
 }

--- a/packages/php-symfony/src/generators/application/generator.spec.ts
+++ b/packages/php-symfony/src/generators/application/generator.spec.ts
@@ -46,5 +46,14 @@ describe('php-symfony generator', () => {
 
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
+    expect(config.targets.lint).toEqual({
+      executor: '@nxt-php/php-symfony:lint',
+      options: {
+        reportScripts: [
+          { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+          { script: 'phpstan-ci', suffix: 'phpstan' },
+        ],
+      },
+    });
   });
 });

--- a/packages/php-symfony/src/generators/application/generator.ts
+++ b/packages/php-symfony/src/generators/application/generator.ts
@@ -67,6 +67,12 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
       },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
+        options: {
+          reportScripts: [
+            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+            { script: 'phpstan-ci', suffix: 'phpstan' },
+          ],
+        },
       },
       test: {
         executor: '@nxt-php/php-symfony:test',

--- a/packages/php-symfony/src/generators/library/generator.spec.ts
+++ b/packages/php-symfony/src/generators/library/generator.spec.ts
@@ -45,5 +45,14 @@ describe('php-symfony generator', () => {
 
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
+    expect(config.targets.lint).toEqual({
+      executor: '@nxt-php/php-symfony:lint',
+      options: {
+        reportScripts: [
+          { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+          { script: 'phpstan-ci', suffix: 'phpstan' },
+        ],
+      },
+    });
   });
 });

--- a/packages/php-symfony/src/generators/library/generator.ts
+++ b/packages/php-symfony/src/generators/library/generator.ts
@@ -67,6 +67,12 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
       },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
+        options: {
+          reportScripts: [
+            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+            { script: 'phpstan-ci', suffix: 'phpstan' },
+          ],
+        },
       },
       test: {
         executor: '@nxt-php/php-symfony:test',


### PR DESCRIPTION
Closes #6.

## Summary

Replaces direct tool detection and invocation (parallel-lint, php-cs-fixer, phpstan, bin/console lint:*) with a composer script dispatcher. Tool configuration and selection moves entirely into `composer.json`, removing the need to update the executor when tools change.

## Execution model

**Without `outputFile`** (local use):
```
composer run lint
```

**With `outputFile`** (CI):
```
composer run lint-static          # static checks; aborts on failure
composer run lint-cs-ci > gl-cs-fixer.json 2>/dev/null
composer run phpstan-ci  > gl-phpstan.json  2>/dev/null
```

Report scripts and their output filename suffixes are configured per project via `reportScripts`:

```json
"options": {
  "outputFile": "gl.json",
  "reportScripts": [
    { "script": "lint-cs-ci",  "suffix": "cs-fixer" },
    { "script": "phpstan-ci",  "suffix": "phpstan" }
  ]
}
```

The filename is derived from `outputFile` by inserting the suffix before the extension: `gl.json` + `cs-fixer` → `gl-cs-fixer.json`.

## Breaking changes

- Removes `fix`, `ignoreEnv`, `format` options from the lint executor schema.
- Projects must define composer scripts (`lint`, `lint-static`, etc.) in their `composer.json`.

## Required setup before first release

`NPM_TOKEN` secret must be set in repository settings.