### PR TITLE
fix: set releaseTagPattern to match existing tags without v-prefix

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -70,6 +70,7 @@
       "preVersionCommand": "npx nx run-many -t build",
       "manifestRootsToUpdate": ["dist/{projectRoot}"]
     },
+    "releaseTagPattern": "{version}",
     "publish": {
       "packageRoot": "dist/{projectRoot}"
     },


### PR DESCRIPTION
nx release defaults to searching for tags matching `v{version}` (e.g. `v8.0.0`), but all existing tags in this repo use no prefix (e.g. `8.0.0`).

Sets `releaseTagPattern: "{version}"` so nx release finds `8.0.0` as the base and creates `9.0.0` for the next release.