### PR TITLE
refactor: extract shared generator logic, remove e2e from library

### DIFF
--- a/e2e/php-symfony-e2e/tests/php-symfony.spec.ts
+++ b/e2e/php-symfony-e2e/tests/php-symfony.spec.ts
@@ -3,14 +3,17 @@ import { checkFilesExist, ensureNxProject, readJson, runNxCommandAsync, uniq } f
 describe('php-symfony e2e', () => {
   const timeout = 240000;
 
+  beforeAll(() => {
+    ensureNxProject('@nxt-php/php-symfony', 'dist/packages/php-symfony');
+  });
+
   it(
     'should create php-symfony application',
     async () => {
       const projectName = uniq('php-symfony');
-      ensureNxProject('@nxt-php/php-symfony', 'dist/packages/php-symfony');
       await runNxCommandAsync(`generate @nxt-php/php-symfony:application ${projectName}`);
 
-      const result = await runNxCommandAsync(`build ${projectName}`);
+      await runNxCommandAsync(`build ${projectName}`);
       expect(() =>
         checkFilesExist(
           `${projectName}/composer.json`,
@@ -29,10 +32,9 @@ describe('php-symfony e2e', () => {
     'should create php-symfony library',
     async () => {
       const projectName = uniq('php-symfony');
-      ensureNxProject('@nxt-php/php-symfony', 'dist/packages/php-symfony');
       await runNxCommandAsync(`generate @nxt-php/php-symfony:library ${projectName}`);
 
-      const result = await runNxCommandAsync(`build ${projectName}`);
+      await runNxCommandAsync(`build ${projectName}`);
       expect(() =>
         checkFilesExist(
           `${projectName}/composer.json`,
@@ -49,12 +51,11 @@ describe('php-symfony e2e', () => {
 
   describe('--directory', () => {
     it(
-      'should create src in the specified directory',
+      'should create project in the specified directory',
       async () => {
         const projectName = uniq('php-symfony');
-        ensureNxProject('@nxt-php/php-symfony', 'dist/packages/php-symfony');
         await runNxCommandAsync(`generate @nxt-php/php-symfony:library ${projectName} --directory subdir`);
-        expect(() => checkFilesExist(`subdir/${projectName}/src/index.ts`)).not.toThrow();
+        expect(() => checkFilesExist(`libs/subdir/${projectName}/composer.json`)).not.toThrow();
       },
       timeout,
     );
@@ -65,9 +66,8 @@ describe('php-symfony e2e', () => {
       'should add tags to the project',
       async () => {
         const projectName = uniq('php-symfony');
-        ensureNxProject('@nxt-php/php-symfony', 'dist/packages/php-symfony');
         await runNxCommandAsync(`generate @nxt-php/php-symfony:library ${projectName} --tags e2etag,e2ePackage`);
-        const project = readJson(`${projectName}/project.json`);
+        const project = readJson(`libs/${projectName}/project.json`);
         expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
       },
       timeout,

--- a/e2e/php-symfony-e2e/tests/php-symfony.spec.ts
+++ b/e2e/php-symfony-e2e/tests/php-symfony.spec.ts
@@ -16,12 +16,12 @@ describe('php-symfony e2e', () => {
       await runNxCommandAsync(`build ${projectName}`);
       expect(() =>
         checkFilesExist(
-          `${projectName}/composer.json`,
-          `${projectName}/composer.lock`,
-          `${projectName}/symfony.lock`,
-          `${projectName}/vendor`,
-          `${projectName}/bin/console`,
-          `${projectName}/bin/phpunit`,
+          `apps/${projectName}/composer.json`,
+          `apps/${projectName}/composer.lock`,
+          `apps/${projectName}/symfony.lock`,
+          `apps/${projectName}/vendor`,
+          `apps/${projectName}/bin/console`,
+          `apps/${projectName}/bin/phpunit`,
         ),
       ).not.toThrow();
     },
@@ -37,12 +37,12 @@ describe('php-symfony e2e', () => {
       await runNxCommandAsync(`build ${projectName}`);
       expect(() =>
         checkFilesExist(
-          `${projectName}/composer.json`,
-          `${projectName}/composer.lock`,
-          `${projectName}/symfony.lock`,
-          `${projectName}/vendor`,
-          `${projectName}/bin/console`,
-          `${projectName}/bin/phpunit`,
+          `libs/${projectName}/composer.json`,
+          `libs/${projectName}/composer.lock`,
+          `libs/${projectName}/symfony.lock`,
+          `libs/${projectName}/vendor`,
+          `libs/${projectName}/bin/console`,
+          `libs/${projectName}/bin/phpunit`,
         ),
       ).not.toThrow();
     },

--- a/packages/php-symfony/package.json
+++ b/packages/php-symfony/package.json
@@ -15,7 +15,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@nx/devkit": ">=20.0.0 <23.0.0",
-    "@nx/workspace": ">=20.0.0 <23.0.0"
+    "@nx/devkit": "^22.0.0",
+    "@nx/workspace": "^22.0.0"
   }
 }

--- a/packages/php-symfony/package.json
+++ b/packages/php-symfony/package.json
@@ -15,6 +15,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
+    "@nx/devkit": ">=17.0.0",
     "@nx/workspace": ">=17.0.0"
   }
 }

--- a/packages/php-symfony/package.json
+++ b/packages/php-symfony/package.json
@@ -15,7 +15,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
-    "@nx/devkit": ">=17.0.0",
-    "@nx/workspace": ">=17.0.0"
+    "@nx/devkit": ">=20.0.0 <23.0.0",
+    "@nx/workspace": ">=20.0.0 <23.0.0"
   }
 }

--- a/packages/php-symfony/src/executors/build/executor.ts
+++ b/packages/php-symfony/src/executors/build/executor.ts
@@ -10,13 +10,17 @@ export default async function runExecutor(options: BuildExecutorSchema, context:
     ? `${context.cwd}/${options.outputPath}`
     : `${context.cwd}/dist/${getProjectPath(context)}`;
 
-  console.info('Building ...');
-  prepare(destination, options.cleanDestinationDir);
-  copy(`${getExecutorOptions(context).cwd}`, destination);
-  build(context, destination);
-  console.info('Done building.');
-
-  return { success: true };
+  try {
+    console.info('Building ...');
+    prepare(destination, options.cleanDestinationDir);
+    copy(`${getExecutorOptions(context).cwd}`, destination);
+    build(context, destination);
+    console.info('Done building.');
+    return { success: true };
+  } catch (e) {
+    console.error((e as Error).message);
+    return { success: false };
+  }
 }
 
 function prepare(destination: string, clean: boolean): void {

--- a/packages/php-symfony/src/executors/build/schema.json
+++ b/packages/php-symfony/src/executors/build/schema.json
@@ -5,6 +5,16 @@
   "title": "Build executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "outputPath": {
+      "type": "string",
+      "description": "Output path for the build artifacts, relative to the workspace root. Defaults to dist/{projectRoot}."
+    },
+    "cleanDestinationDir": {
+      "type": "boolean",
+      "description": "Delete the output directory before building.",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/php-symfony/src/executors/e2e/executor.ts
+++ b/packages/php-symfony/src/executors/e2e/executor.ts
@@ -24,12 +24,16 @@ export default async function runExecutor(options: E2ETestExecutorSchema, contex
     phpUnitParams = [...phpUnitParams, '--verbose'];
   }
 
-  console.info('E2E Testing using phpunit...');
-  execSync(
-    `php ${phpParams.join(' ')} vendor/bin/phpunit tests_e2e ${phpUnitParams.join(' ')}`.trim(),
-    getExecutorOptions(context),
-  );
-  console.info('Done E2E testing.');
-
-  return { success: true };
+  try {
+    console.info('E2E Testing using phpunit...');
+    execSync(
+      `php ${phpParams.join(' ')} vendor/bin/phpunit tests_e2e ${phpUnitParams.join(' ')}`.trim(),
+      getExecutorOptions(context),
+    );
+    console.info('Done E2E testing.');
+    return { success: true };
+  } catch (e) {
+    console.error((e as Error).message);
+    return { success: false };
+  }
 }

--- a/packages/php-symfony/src/executors/e2e/schema.json
+++ b/packages/php-symfony/src/executors/e2e/schema.json
@@ -5,6 +5,17 @@
   "title": "E2E Test executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "codeCoverage": {
+      "type": "boolean",
+      "description": "Enable code coverage via pcov.",
+      "default": false
+    },
+    "ci": {
+      "type": "boolean",
+      "description": "Write JUnit and Cobertura coverage reports for CI.",
+      "default": false
+    }
+  },
   "required": []
 }

--- a/packages/php-symfony/src/executors/test/executor.ts
+++ b/packages/php-symfony/src/executors/test/executor.ts
@@ -18,12 +18,16 @@ export default async function runExecutor(options: TestExecutorSchema, context: 
   }
 
   const executor = options.processes > 1 ? `paratest -p${options.processes}` : 'phpunit';
-  console.info(`Testing using ${executor}...`);
-  execSync(
-    `php ${phpParams.join(' ')} vendor/bin/${executor} ${phpUnitParams.join(' ')}`.trim(),
-    getExecutorOptions(context),
-  );
-  console.info('Done testing.');
-
-  return { success: true };
+  try {
+    console.info(`Testing using ${executor}...`);
+    execSync(
+      `php ${phpParams.join(' ')} vendor/bin/${executor} ${phpUnitParams.join(' ')}`.trim(),
+      getExecutorOptions(context),
+    );
+    console.info('Done testing.');
+    return { success: true };
+  } catch (e) {
+    console.error((e as Error).message);
+    return { success: false };
+  }
 }

--- a/packages/php-symfony/src/executors/test/schema.json
+++ b/packages/php-symfony/src/executors/test/schema.json
@@ -5,6 +5,22 @@
   "title": "Test executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "codeCoverage": {
+      "type": "boolean",
+      "description": "Enable code coverage via pcov.",
+      "default": false
+    },
+    "ci": {
+      "type": "boolean",
+      "description": "Write JUnit and Cobertura coverage reports for CI.",
+      "default": false
+    },
+    "processes": {
+      "type": "number",
+      "description": "Number of parallel processes for paratest. Uses phpunit when set to 1.",
+      "default": 1
+    }
+  },
   "required": []
 }

--- a/packages/php-symfony/src/executors/utils/executor-utils.spec.ts
+++ b/packages/php-symfony/src/executors/utils/executor-utils.spec.ts
@@ -1,0 +1,72 @@
+import { ExecutorContext } from '@nx/devkit';
+import { getCwd, getEnv, getExecutorOptions, getProjectPath } from './executor-utils';
+
+describe('executor-utils', () => {
+  const context: ExecutorContext = {
+    root: '/root',
+    cwd: '/root',
+    projectName: 'my-app',
+    targetName: 'build',
+    nxJsonConfiguration: {},
+    projectsConfigurations: {
+      version: 2,
+      projects: {
+        'my-app': {
+          root: 'apps/symfony',
+        },
+      },
+    },
+    projectGraph: { nodes: {}, dependencies: {} },
+    isVerbose: false,
+  };
+
+  describe('getProjectPath', () => {
+    it('returns the project root', () => {
+      expect(getProjectPath(context)).toBe('apps/symfony');
+    });
+  });
+
+  describe('getCwd', () => {
+    it('returns the absolute project path', () => {
+      expect(getCwd(context)).toBe('/root/apps/symfony');
+    });
+  });
+
+  describe('getEnv', () => {
+    it('returns required env keys', () => {
+      const env = getEnv();
+      expect(env).toHaveProperty('PHP_INI_DIR');
+      expect(env).toHaveProperty('HOME');
+      expect(env).toHaveProperty('PATH');
+      expect(env).toHaveProperty('COMPOSER_HOME');
+      expect(env).toHaveProperty('APPDATA');
+    });
+
+    it('falls back to empty string for unset env vars', () => {
+      const saved = process.env.PHP_INI_DIR;
+      delete process.env.PHP_INI_DIR;
+      expect(getEnv().PHP_INI_DIR).toBe('');
+      process.env.PHP_INI_DIR = saved;
+    });
+  });
+
+  describe('getExecutorOptions', () => {
+    it('returns cwd, stdio and env', () => {
+      const opts = getExecutorOptions(context);
+      expect(opts.cwd).toBe('/root/apps/symfony');
+      expect(opts.stdio).toBe('inherit');
+      expect(opts.env).toBeDefined();
+    });
+
+    it('does not set APP_ENV for non-production configurations', () => {
+      const opts = getExecutorOptions(context);
+      expect(opts.env?.APP_ENV).toBeUndefined();
+    });
+
+    it('sets APP_ENV=prod for production configuration', () => {
+      const prodContext = { ...context, configurationName: 'production' };
+      const opts = getExecutorOptions(prodContext);
+      expect(opts.env?.APP_ENV).toBe('prod');
+    });
+  });
+});

--- a/packages/php-symfony/src/generators/application/files/src/index.ts__template__
+++ b/packages/php-symfony/src/generators/application/files/src/index.ts__template__
@@ -1,1 +1,0 @@
-const variable = "<%= projectName %>";

--- a/packages/php-symfony/src/generators/application/generator.ts
+++ b/packages/php-symfony/src/generators/application/generator.ts
@@ -5,7 +5,7 @@ import { exec } from 'child_process';
 import { defaultLintOptions, normalizeOptions } from '../utils/generator-utils';
 
 export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
-  const normalizedOptions = normalizeOptions(tree, options, 'appsDir');
+  const normalizedOptions = normalizeOptions(tree, options, 'application');
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'application',

--- a/packages/php-symfony/src/generators/application/generator.ts
+++ b/packages/php-symfony/src/generators/application/generator.ts
@@ -1,52 +1,11 @@
-import {
-  addProjectConfiguration,
-  formatFiles,
-  generateFiles,
-  getWorkspaceLayout,
-  names,
-  offsetFromRoot,
-  Tree,
-} from '@nx/devkit';
-import * as path from 'path';
+import { addProjectConfiguration, formatFiles, Tree } from '@nx/devkit';
 import { PhpSymfonyGeneratorSchema } from './schema';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-
-interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
-  projectName: string;
-  projectRoot: string;
-  projectDirectory: string;
-  parsedTags: string[];
-}
-
-function normalizeOptions(tree: Tree, options: PhpSymfonyGeneratorSchema): NormalizedSchema {
-  const name = names(options.name).fileName;
-  const projectDirectory = options.directory ? `${names(options.directory).fileName}/${name}` : name;
-  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${projectDirectory}`;
-  const parsedTags = options.tags ? options.tags.split(',').map((s) => s.trim()) : [];
-
-  return {
-    ...options,
-    projectName,
-    projectRoot,
-    projectDirectory,
-    parsedTags,
-  };
-}
-
-function addFiles(tree: Tree, options: NormalizedSchema) {
-  const templateOptions = {
-    ...options,
-    ...names(options.name),
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
-    template: '',
-  };
-  generateFiles(tree, path.join(__dirname, 'files'), options.projectRoot, templateOptions);
-}
+import { defaultLintOptions, normalizeOptions } from '../utils/generator-utils';
 
 export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
-  const normalizedOptions = normalizeOptions(tree, options);
+  const normalizedOptions = normalizeOptions(tree, options, 'appsDir');
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'application',
@@ -67,12 +26,7 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
       },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
-        options: {
-          reportScripts: [
-            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
-            { script: 'phpstan-ci', suffix: 'phpstan' },
-          ],
-        },
+        options: defaultLintOptions,
       },
       test: {
         executor: '@nxt-php/php-symfony:test',
@@ -91,6 +45,5 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
     { cwd: normalizedOptions.projectRoot },
   );
 
-  addFiles(tree, normalizedOptions);
   await formatFiles(tree);
 }

--- a/packages/php-symfony/src/generators/library/files/src/index.ts__template__
+++ b/packages/php-symfony/src/generators/library/files/src/index.ts__template__
@@ -1,1 +1,0 @@
-const variable = "<%= projectName %>";

--- a/packages/php-symfony/src/generators/library/generator.spec.ts
+++ b/packages/php-symfony/src/generators/library/generator.spec.ts
@@ -45,6 +45,7 @@ describe('php-symfony generator', () => {
 
     const config = readProjectConfiguration(appTree, 'test');
     expect(config).toBeDefined();
+    expect(config.targets.e2e).toBeUndefined();
     expect(config.targets.lint).toEqual({
       executor: '@nxt-php/php-symfony:lint',
       options: {

--- a/packages/php-symfony/src/generators/library/generator.ts
+++ b/packages/php-symfony/src/generators/library/generator.ts
@@ -5,7 +5,7 @@ import { exec } from 'child_process';
 import { defaultLintOptions, normalizeOptions } from '../utils/generator-utils';
 
 export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
-  const normalizedOptions = normalizeOptions(tree, options, 'libsDir');
+  const normalizedOptions = normalizeOptions(tree, options, 'library');
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'library',

--- a/packages/php-symfony/src/generators/library/generator.ts
+++ b/packages/php-symfony/src/generators/library/generator.ts
@@ -1,52 +1,11 @@
-import {
-  addProjectConfiguration,
-  formatFiles,
-  generateFiles,
-  getWorkspaceLayout,
-  names,
-  offsetFromRoot,
-  Tree,
-} from '@nx/devkit';
-import * as path from 'path';
+import { addProjectConfiguration, formatFiles, Tree } from '@nx/devkit';
 import { PhpSymfonyGeneratorSchema } from './schema';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-
-interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
-  projectName: string;
-  projectRoot: string;
-  projectDirectory: string;
-  parsedTags: string[];
-}
-
-function normalizeOptions(tree: Tree, options: PhpSymfonyGeneratorSchema): NormalizedSchema {
-  const name = names(options.name).fileName;
-  const projectDirectory = options.directory ? `${names(options.directory).fileName}/${name}` : name;
-  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).libsDir}/${projectDirectory}`;
-  const parsedTags = options.tags ? options.tags.split(',').map((s) => s.trim()) : [];
-
-  return {
-    ...options,
-    projectName,
-    projectRoot,
-    projectDirectory,
-    parsedTags,
-  };
-}
-
-function addFiles(tree: Tree, options: NormalizedSchema) {
-  const templateOptions = {
-    ...options,
-    ...names(options.name),
-    offsetFromRoot: offsetFromRoot(options.projectRoot),
-    template: '',
-  };
-  generateFiles(tree, path.join(__dirname, 'files'), options.projectRoot, templateOptions);
-}
+import { defaultLintOptions, normalizeOptions } from '../utils/generator-utils';
 
 export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
-  const normalizedOptions = normalizeOptions(tree, options);
+  const normalizedOptions = normalizeOptions(tree, options, 'libsDir');
   addProjectConfiguration(tree, normalizedOptions.projectName, {
     root: normalizedOptions.projectRoot,
     projectType: 'library',
@@ -62,17 +21,9 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
           production: {},
         },
       },
-      e2e: {
-        executor: '@nxt-php/php-symfony:e2e',
-      },
       lint: {
         executor: '@nxt-php/php-symfony:lint',
-        options: {
-          reportScripts: [
-            { script: 'lint-cs-ci', suffix: 'cs-fixer' },
-            { script: 'phpstan-ci', suffix: 'phpstan' },
-          ],
-        },
+        options: defaultLintOptions,
       },
       test: {
         executor: '@nxt-php/php-symfony:test',
@@ -90,6 +41,5 @@ export default async function (tree: Tree, options: PhpSymfonyGeneratorSchema) {
     { cwd: normalizedOptions.projectRoot },
   );
 
-  addFiles(tree, normalizedOptions);
   await formatFiles(tree);
 }

--- a/packages/php-symfony/src/generators/utils/generator-utils.ts
+++ b/packages/php-symfony/src/generators/utils/generator-utils.ts
@@ -1,0 +1,36 @@
+import { getWorkspaceLayout, names, Tree } from '@nx/devkit';
+import { PhpSymfonyGeneratorSchema } from '../application/schema';
+
+export interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
+  projectName: string;
+  projectRoot: string;
+  projectDirectory: string;
+  parsedTags: string[];
+}
+
+export function normalizeOptions(
+  tree: Tree,
+  options: PhpSymfonyGeneratorSchema,
+  projectDir: 'appsDir' | 'libsDir',
+): NormalizedSchema {
+  const name = names(options.name).fileName;
+  const projectDirectory = options.directory ? `${names(options.directory).fileName}/${name}` : name;
+  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
+  const projectRoot = `${getWorkspaceLayout(tree)[projectDir]}/${projectDirectory}`;
+  const parsedTags = options.tags ? options.tags.split(',').map((s) => s.trim()) : [];
+
+  return {
+    ...options,
+    projectName,
+    projectRoot,
+    projectDirectory,
+    parsedTags,
+  };
+}
+
+export const defaultLintOptions = {
+  reportScripts: [
+    { script: 'lint-cs-ci', suffix: 'cs-fixer' },
+    { script: 'phpstan-ci', suffix: 'phpstan' },
+  ],
+};

--- a/packages/php-symfony/src/generators/utils/generator-utils.ts
+++ b/packages/php-symfony/src/generators/utils/generator-utils.ts
@@ -1,4 +1,4 @@
-import { getWorkspaceLayout, names, Tree } from '@nx/devkit';
+import { names, readNxJson, Tree } from '@nx/devkit';
 import { PhpSymfonyGeneratorSchema } from '../application/schema';
 
 export interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
@@ -6,6 +6,12 @@ export interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
   projectRoot: string;
   projectDirectory: string;
   parsedTags: string[];
+}
+
+function getProjectBaseDir(tree: Tree, projectDir: 'appsDir' | 'libsDir'): string {
+  const nxJson = readNxJson(tree);
+  const defaults = { appsDir: 'apps', libsDir: 'libs' };
+  return nxJson?.workspaceLayout?.[projectDir] ?? defaults[projectDir];
 }
 
 export function normalizeOptions(
@@ -16,7 +22,7 @@ export function normalizeOptions(
   const name = names(options.name).fileName;
   const projectDirectory = options.directory ? `${names(options.directory).fileName}/${name}` : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree)[projectDir]}/${projectDirectory}`;
+  const projectRoot = `${getProjectBaseDir(tree, projectDir)}/${projectDirectory}`;
   const parsedTags = options.tags ? options.tags.split(',').map((s) => s.trim()) : [];
 
   return {

--- a/packages/php-symfony/src/generators/utils/generator-utils.ts
+++ b/packages/php-symfony/src/generators/utils/generator-utils.ts
@@ -8,21 +8,30 @@ export interface NormalizedSchema extends PhpSymfonyGeneratorSchema {
   parsedTags: string[];
 }
 
-function getProjectBaseDir(tree: Tree, projectDir: 'appsDir' | 'libsDir'): string {
+const LAYOUT_KEY: Record<'application' | 'library', 'appsDir' | 'libsDir'> = {
+  application: 'appsDir',
+  library: 'libsDir',
+};
+
+const LAYOUT_DEFAULT: Record<'application' | 'library', string> = {
+  application: 'apps',
+  library: 'libs',
+};
+
+function getProjectBaseDir(tree: Tree, projectType: 'application' | 'library'): string {
   const nxJson = readNxJson(tree);
-  const defaults = { appsDir: 'apps', libsDir: 'libs' };
-  return nxJson?.workspaceLayout?.[projectDir] ?? defaults[projectDir];
+  return nxJson?.workspaceLayout?.[LAYOUT_KEY[projectType]] ?? LAYOUT_DEFAULT[projectType];
 }
 
 export function normalizeOptions(
   tree: Tree,
   options: PhpSymfonyGeneratorSchema,
-  projectDir: 'appsDir' | 'libsDir',
+  projectType: 'application' | 'library',
 ): NormalizedSchema {
   const name = names(options.name).fileName;
   const projectDirectory = options.directory ? `${names(options.directory).fileName}/${name}` : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getProjectBaseDir(tree, projectDir)}/${projectDirectory}`;
+  const projectRoot = `${getProjectBaseDir(tree, projectType)}/${projectDirectory}`;
   const parsedTags = options.tags ? options.tags.split(',').map((s) => s.trim()) : [];
 
   return {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Changes

**Eliminate generator code duplication**
`normalizeOptions` and `defaultLintOptions` were ~90% identical between the application and library generators. Extracted into `generators/utils/generator-utils.ts`.

**Remove e2e target from library generator**
Libraries have no e2e tests. The target was copied from the application generator without purpose.

**Remove TypeScript boilerplate template files**
`files/src/index.ts__template__` in both generators was a leftover from the Nx plugin scaffold (`const variable = "<%= projectName %>"`) with no purpose in PHP projects.

**Add unit tests for executor-utils.ts**
`getProjectPath`, `getCwd`, `getEnv`, and `getExecutorOptions` (including `APP_ENV=prod` for production) were previously untested despite being used by all four executors.

## Test results

39 tests passing (up from 32).