### PR TITLE
chore: replace NPM_TOKEN with OIDC trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,5 @@ jobs:
       - name: Release
         run: npx nx release --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

The `NPM_TOKEN` secret had a 90-day expiry and required the "bypass 2FA" option on the token, which is a security concern. By configuring GitHub Actions as a trusted publisher on npmjs.com, authentication is handled via OIDC — no stored token, no expiry, no manual rotation.

## Changes

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the release workflow

The existing `id-token: write` permission and `NPM_CONFIG_PROVENANCE: true` already provide everything needed for OIDC-based publishing.

## Prerequisites

- GitHub Actions configured as trusted publisher on npmjs.com for `@nxt-php/php-symfony`
- Package setting set to "Require 2FA and disallow tokens"
- `NPM_TOKEN` secret can be deleted from repository settings