### PR TITLE
fix: format CHANGELOG.md after nx release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Format changelog
+        run: |
+          npx prettier --write CHANGELOG.md
+          git diff --quiet CHANGELOG.md || git commit --amend --no-edit CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,18 @@
 ### 🚀 Features
 
 - add CI pipeline and release workflow ([#8](https://github.com/jotwea/nxt-php/pull/8))
-- ⚠️  delegate lint executor to composer scripts ([#10](https://github.com/jotwea/nxt-php/pull/10))
+- ⚠️ delegate lint executor to composer scripts ([#10](https://github.com/jotwea/nxt-php/pull/10))
 
 ### 🩹 Fixes
 
 - set publish packageRoot to dist/{projectRoot} ([#11](https://github.com/jotwea/nxt-php/pull/11))
 - set releaseTagPattern to match existing tags without v-prefix ([2fb9b86](https://github.com/jotwea/nxt-php/commit/2fb9b86))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- delegate lint executor to composer scripts  ([#10](https://github.com/jotwea/nxt-php/pull/10))
+- delegate lint executor to composer scripts ([#10](https://github.com/jotwea/nxt-php/pull/10))
   removes fix, ignoreEnv, and format options from the lint executor schema. Projects must define composer scripts (lint, lint-static) in composer.json instead.
-  Replaces direct tool detection (parallel-lint, php-cs-fixer, phpstan, bin/console lint:*) with a composer script dispatcher. Tool selection and configuration moves entirely into composer.json.
+  Replaces direct tool detection (parallel-lint, php-cs-fixer, phpstan, bin/console lint:\*) with a composer script dispatcher. Tool selection and configuration moves entirely into composer.json.
   Without outputFile: runs `composer run lint`.
   With outputFile: runs `lint-static` first (aborts on failure), then each reportScripts entry writes to a derived output path.
 


### PR DESCRIPTION
## Problem

`nx release` generates `CHANGELOG.md` without running it through Prettier, causing `npx nx format:check` in CI to fail with exit code 1.

## Solution

Add a step in the release workflow that runs `prettier --write CHANGELOG.md` after `nx release` and folds the result into the release commit via `git commit --amend --no-edit`. The amend only runs when Prettier actually changes the file.

This keeps the Git history clean (no extra commit) and ensures `format:check` always passes.